### PR TITLE
Feature/spark 2.1

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,15 @@
+v. 1.9.6
+ * Spark is 2.1.0
+ * based on CentOS 7.3
+ * IPython 5.3.0
+ * R 3.3.2
+ * use OpenJDK 8 instead of Oracle Java
+ * no Theano/Keras installation (left to child boxes),
+ * fixes in manager script
+ * custom build of Spark, including native BLAS bindings
+ * sparklyr installed from github
+ * custom Toree build
+ 
 v. 1.9.3
  * Spark is 2.0.2
  * added sparklyr

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+v. 1.9.7
+ * Improved cleanup for box size reduction
+ 
 v. 1.9.6
  * Spark is 2.1.0
  * based on CentOS 7.3

--- a/base/Vagrantfile
+++ b/base/Vagrantfile
@@ -242,6 +242,8 @@ Vagrant.configure(2) do |config|
       ./pip install tables
 
       ./pip install pandas
+      ./pip install bottleneck
+      ./pip install numexpr
       ./pip install statsmodels
       ./pip install scikit-learn
       ./pip install gensim
@@ -456,6 +458,38 @@ Vagrant.configure(2) do |config|
         rm -rf /opt/ipnb/share/jupyter/nbextensions/.git*
         rm -rf /tmp/Rtmp* /var/tmp/yum*
         yum clean all
+
+        # Remove bash history for root
+        unset HISTFILE
+        rm -f /root/.bash_history
+
+        # Cleanup log files
+        echo "Removing logfiles"
+        find /var/log -type f | while read f; do echo -ne '' > $f; done;
+
+        # Remove all temporal files
+        rm -rf /tmp/*
+
+        # Zero free space
+        echo "Whiteout root & boot partitions"
+        for fs in / /boot/
+        do
+           count=$(df --sync -kP / | tail -n1  | awk -F ' ' '{print $4}') 
+           let count--
+           dd if=/dev/zero of=${fs}whitespace bs=1024 count=$count
+           rm ${fs}whitespace;
+        done
+        sync
+
+        # Zero the swap space
+        swappart=$(cat /proc/swaps | tail -n1 | awk -F ' ' '{print $1}')
+        if [ "$swappart" != "" ]; then
+          swapoff $swappart;
+          dd if=/dev/zero of=$swappart;
+          mkswap $swappart;
+          swapon $swappart;
+        fi
+
       SHELL
     end
 

--- a/base/Vagrantfile
+++ b/base/Vagrantfile
@@ -13,7 +13,8 @@ vagrant_command = ARGV[0]
 
 # The version of Spark we will download & install
 spark_version = '2.1.0'
-spark_name = 'spark-' + spark_version + '-bin-hadoop2.6'
+spark_name = 'spark-' + spark_version + '-bin-custom'
+#spark_name = 'spark-' + spark_version + '-bin-hadoop2.6'
 
 # The place where Spark will be deployed inside the local machine
 # There is usually no need to change this
@@ -44,7 +45,7 @@ Vagrant.configure(2) do |config|
   # This is to help later when packaging: don't change the insecure key
   config.ssh.insert_key = false
 
-  config.vm.define "vgr-tid-spark-base64-7" do |vgrspark|
+  config.vm.define "vgr-spark-base64-7" do |vgrspark|
     
     # The most common configuration options are documented and commented below.
     # For a complete reference, please see the online documentation at
@@ -71,7 +72,7 @@ Vagrant.configure(2) do |config|
     #auto_mount: false
   
     # Customize the virtual machine: hostname & RAM
-    vgrspark.vm.hostname = "vgr-tid-spark-base64"
+    vgrspark.vm.hostname = "vgr-spark-base64"
     vgrspark.vm.provider :virtualbox do |vb|
       # Set the hostname in the provider
       vb.name = vgrspark.vm.hostname.to_s
@@ -120,21 +121,21 @@ Vagrant.configure(2) do |config|
     # (inc. development environments we need to install some Python packages)
     vgrspark.vm.provision "01.base",
     type: "shell",
-    privileged: false,
+    privileged: true,
     inline: <<-SHELL
-     sudo yum -y install epel-release
+     yum -y install epel-release
      # Make some subdirectories in the vagrant home dir
-     mkdir bin install tmp
+     sudo -u vagrant -i mkdir bin install tmp
      # Install some basic packages + dev libraries to compile R/Python pkgs
-     sudo yum -y install redhat-lsb-core
-     sudo yum -y install gcc gcc-c++ freetype-devel libpng-devel libffi-devel
-     sudo yum -y install openblas-devel
-     sudo yum -y install python-virtualenv
+     yum -y install redhat-lsb-core
+     yum -y install gcc gcc-c++ freetype-devel libpng-devel libffi-devel
+     yum -y install openblas-devel
+     yum -y install python-virtualenv
      # General utility programs
-     sudo yum -y install man nc emacs-nox nano
+     yum -y install man nc emacs-nox nano
      # Other
      (cd /etc/yum.repos.d; wget http://www.graphviz.org/graphviz-rhel.repo)
-     sudo yum -y install graphviz
+     yum --enablerepo=graphviz-snapshot -y install graphviz
     SHELL
 
     # .........................................
@@ -177,13 +178,15 @@ Vagrant.configure(2) do |config|
      Rscript -e 'devtools::install_github( paste0("IRkernel/",c("repr","IRdisplay","IRkernel")) )'
      #Rscript -e 'install.packages( c("rzmq","repr","IRkernel","IRdisplay"),repos=c("http://irkernel.github.io/","http://ftp.cixug.es/CRAN/","http://cran.es.r-project.org/"),quiet=FALSE)'
      echo "Installing sparklyr"
-     Rscript -e 'install.packages( "sparklyr",dependencies=TRUE,repos=c("http://ftp.cixug.es/CRAN/","http://cran.es.r-project.org/"),quiet=FALSE)'
+     # As of March 2017, we need to install from git to have support for 2.1
+     #Rscript -e 'install.packages( "sparklyr",dependencies=TRUE,repos=c("http://ftp.cixug.es/CRAN/","http://cran.es.r-project.org/"),quiet=FALSE)'
+     Rscript -e 'devtools::install_github("rstudio/sparklyr")'
      yum erase -y postgresql-devel mysql-devel cairo-devel gl-manpages glib2-devel libssh2-devel
     SHELL
 
 
     # .........................................
-    # Install Python 2.7 by using the Sofware Collections (SCL)
+    # Install Python 2.7 by using the Software Collections (SCL)
 #    vgrspark.vm.provision "10.py27.scl", 
 #    type: "shell", 
 #    inline: <<-SHELL
@@ -209,9 +212,8 @@ Vagrant.configure(2) do |config|
      virtualenv /opt/ipnb --no-site-packages
 
      cd $HOME/bin
-     rm python python2.7 pip
+     rm -f python python2.7 pip
      ln -s /opt/ipnb/bin/{python,python2.7,pip} .
-
    SHELL
 
 
@@ -277,7 +279,9 @@ Vagrant.configure(2) do |config|
 
 
     # .........................................
-    # Install Spark
+    # Install a pre-built Spark
+    # We can either install a version we download from a Spark website mirror, or
+    # a locally built custom version
     vgrspark.vm.provision "30.spark",
     type: "shell",
     privileged: false,
@@ -286,11 +290,16 @@ Vagrant.configure(2) do |config|
     inline: <<-SHELL
 
       # download & install Spark
-      cd install
-      echo "Downloading $2.tgz"
-      wget --no-verbose "http://apache.rediris.es/spark/spark-$1/$2.tgz"
       sudo bash -c "mkdir -m 775 '$3'; chown vagrant.vagrant '$3'; cd $3; rm -f current; ln -s $2/ current"
-      tar zxvf "$2.tgz" -C "$3"
+      case $2 in
+        *custom) 
+           file="/vagrant/spark/$2.tgz";;
+        *) echo "Downloading $2.tgz"
+           cd install
+           wget --no-verbose "http://apache.rediris.es/spark/spark-$1/$2.tgz"
+           file=$2.tgz;;
+      esac
+      tar zxvf "$file" -C "$3"
       sudo sh -c "echo 'PATH=\\$PATH:$3/current/bin' > /etc/profile.d/spark-path.sh"
 
       # Create the directory to place Hadoop config
@@ -313,7 +322,7 @@ Vagrant.configure(2) do |config|
 
     # .........................................
     # No Spark add-ons installed
-    #  * spark-csv is now part of Spark 2.0
+    #  * spark-csv is now part of Spark 2.x
     #  * GraphFrames & Kafka Streaming can be declared as packages in
     #    Spark config and they will be automatically downloaded
 
@@ -352,18 +361,27 @@ Vagrant.configure(2) do |config|
 
     # .........................................
     # Install the Toree Scala/Spark kernel
+    # We use a custom-built version compiled from master, to make sure that
+    # PR100 (https://github.com/apache/incubator-toree/pull/100), which fixes
+    # syntax highlighting, is included
     vgrspark.vm.provision "36.scala-kernel",
     type: "shell",
     privileged: false,
     keep_color: true,
     args: [ spark_version, spark_name, spark_basedir, repo_base ],
     inline: <<-SHELL
-      # Install the (Scala) Spark kernel
-      #pip install toree
-      cd $HOME/install
       PKG=toree-0.2.0.dev1.tar.gz
+      echo "Installing the (Scala) Spark kernel $PKG"
+      # -- From PyPi
+      #pip install toree
+      # -- From the developer snapshot
+      #pip install https://dist.apache.org/repos/dist/dev/incubator/toree/0.2.0/snapshots/dev1/toree-pip/$PKG
+      # -- From a local repository
+      #cd $HOME/install
       #wget --no-verbose "${4}spark-kernel/$1/$PKG"
-      pip install /vagrant/$PKG 
+      #pip install $PKG
+      # -- From a locally available file
+      pip install /vagrant/toree/$PKG 
     SHELL
 
 
@@ -432,10 +450,12 @@ Vagrant.configure(2) do |config|
       type: "shell",
       privileged: true,
       inline: <<-SHELL
+        echo "Cleaning temporal & installation files"
+        HH=/home/vagrant
+        rm -rf $HH/.cache/pip $HH/.bash_history $HH/install/*
         rm -rf /opt/ipnb/share/jupyter/nbextensions/.git*
-        rm -rf /home/vagrant/.cache/pip /home/vagrant/.bash_history /home/vagrant/install/*
         rm -rf /tmp/Rtmp* /var/tmp/yum*
-        sudo yum clean all
+        yum clean all
       SHELL
     end
 

--- a/base/Vagrantfile
+++ b/base/Vagrantfile
@@ -12,7 +12,7 @@ vagrant_command = ARGV[0]
 
 
 # The version of Spark we will download & install
-spark_version = '2.0.2'
+spark_version = '2.1.0'
 spark_name = 'spark-' + spark_version + '-bin-hadoop2.6'
 
 # The place where Spark will be deployed inside the local machine
@@ -52,10 +52,11 @@ Vagrant.configure(2) do |config|
 
     # The base box we will be using. 
     # Available at https://atlas.hashicorp.com/search
-    vgrspark.vm.box = "bento/centos-7.2"
-    vgrspark.vm.box_version = "2.2.9"
+    vgrspark.vm.box = "bento/centos-7.3"
+    #vgrspark.vm.box_version = "2.2.9"
     # v. 2.3.0 has a regression problem with some VirtualBox versions
     # see https://github.com/chef/bento/issues/688
+    # A workaround is included below
 
     # Disable automatic box update checking. If you disable this, then
     # boxes will only be checked for updates when the user runs
@@ -78,6 +79,9 @@ Vagrant.configure(2) do |config|
       vb.memory = "1024"
       # Display the VirtualBox GUI when booting the machine
       #vb.gui = true
+      # A patch for a problem in VirtualBox -- fixed in VB 5.0.28 and 5.1.6
+      # see https://github.com/chef/bento/issues/688
+      vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
     end
 
     # Networking
@@ -118,7 +122,7 @@ Vagrant.configure(2) do |config|
     type: "shell",
     privileged: false,
     inline: <<-SHELL
-     sudo yum install epel-release
+     sudo yum -y install epel-release
      # Make some subdirectories in the vagrant home dir
      mkdir bin install tmp
      # Install some basic packages + dev libraries to compile R/Python pkgs
@@ -137,18 +141,7 @@ Vagrant.configure(2) do |config|
     # We install now OpenJDK 8 instead of Oracle 8
     vgrspark.vm.provision "02.jdk",
     type: "shell", 
-    inline: <<-SHELL
-     sudo yum -y install java-1.8.0-openjdk-devel
-
-     #cd install
-     #VERSION=8u111
-     #echo "Downloading jdk-$VERSION"
-     #download Oracle 8 from oracle.com, with the dark magic needed to 
-     #accept their license before downloading
-     #wget --no-verbose --no-cookies --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/${VERSION}-b14/jdk-${VERSION}-linux-x64.rpm"
-     #sudo yum -y install jdk-${VERSION}-linux-x64.rpm
-
-    SHELL
+    inline: "sudo yum -y install java-1.8.0-openjdk-devel"
    # http://stackoverflow.com/questions/10268583/downloading-java-jdk-on-linux-via-wget-is-shown-license-page-instead
 
     # Install R from EPEL
@@ -254,8 +247,6 @@ Vagrant.configure(2) do |config|
       ./pip install mpld3
       ./pip install seaborn
 
-      ./pip install theano
-      ./pip install keras
       ./pip install pydot-ng
       ./pip install graphviz
 

--- a/base/buildfiles/conf/spark-defaults.conf.local
+++ b/base/buildfiles/conf/spark-defaults.conf.local
@@ -9,7 +9,7 @@ spark.eventLog.enabled=true
 spark.eventLog.dir=/var/log/ipnb
 
 # This is needed if we use the Graphframes library
-#spark.jars.packages=graphframes:graphframes:0.2.0-spark2.0-s_2.11
+#spark.jars.packages=graphframes:graphframes:0.4.0-spark2.1-s_2.11
 
 # And this if we need Kafka integration in Spark Streaming. Using Kafka 0.8
 # (since the 0.10 version w/ the new consumer API does not yet work in Python) 

--- a/base/buildfiles/conf/spark-env.sh.local
+++ b/base/buildfiles/conf/spark-env.sh.local
@@ -9,5 +9,10 @@ unset HADOOP_CONF_DIR
 # Set the Python to use for executors
 PYSPARK_PYTHON=/opt/ipnb/bin/python2.7
 
+# This enables netlib-java to use the optimized BLAS libraries
+# For this to work, the Spark distribution needs to contain the native reference
+# implementation (which binary pre-built packages do not usually include)
+LD_PRELOAD=/usr/lib64/libopenblas.so
+
 # Default arguments for job submission
 PYSPARK_SUBMIT_ARGS='--master local[*] --driver-memory 1536M --num-executors 2 --executor-cores 2 --executor-memory 1g'

--- a/base/buildfiles/jupyter-notebook-mgr
+++ b/base/buildfiles/jupyter-notebook-mgr
@@ -150,14 +150,16 @@ set_mode()
     check_for_root
     test -f "/opt/spark/current/conf/spark-env.sh.$MODE" || { log_failure_msg "Error: config for $MODE missing. Probably needs set-addr"; return 1; }
     #test -f "${CFGNAME}.$MODE" || { log_failure_msg "can't find Spark config ${CFGNAME}.$MODE"; return 1; }
-    stop
+    checkstatusofproc && RUNNING=1
+    test "$RUNNING" && { stop || return 1; }
     #echo "$MODE" > ${CFGNAME}
     (cd /opt/spark/current/conf; \
 	rm -f spark-env.sh spark-defaults.conf; \
 	ln -s spark-env.sh.$MODE spark-env.sh; \
 	ln -s spark-defaults.conf.$MODE spark-defaults.conf) 
     log_success_msg "Configured Spark for mode: $MODE "
-    start
+    test "$RUNNING" && { start; return $?; }
+    return 0
 }
 
 


### PR DESCRIPTION
* Base box moved to CentOS 7.3
* Spark moved to 2.1.0
* Use OpenJDK 8 instead of Oracle Java
* Remove installation of theano & keras (to be installed in child boxes)
* custom build of Spark (to include native BLAS libraries)
* define `LD_PRELOAD` for native BLAS libraries to be detected
* use custom Toree build
* install `sparklyr` from github
* added Python packages: `bottleneck` & `numexpr`
* Workaround for problems in certain VirtualBox versions
* small fixes
* Improved cleanup for box reduction
* Updated GraphFrames version number in config file
* bugfix: notebook-mgr script set_mode only stops-start when running